### PR TITLE
removes logic for link to see all stations from stations dash.

### DIFF
--- a/app/views/stations/dash.html.erb
+++ b/app/views/stations/dash.html.erb
@@ -1,11 +1,7 @@
 <h1>Stations Dashboard</h1>
 
 </br>
-  <% if current_user && current_user.admin? %>
-    <%= link_to "See all Stations", admin_stations_path %>
-  <% else %>
     <%= link_to "See all Stations", stations_path %>
-  <% end %>
 </br>
 
 <h2>Total Stations Count: <%= @count %></h2>


### PR DESCRIPTION
____ Wrote Tests
__x__ Implemented
__x__ Reviewed
# Neccesary checkmarks:
- [x] All Tests are Passing

- [x] The code will run locally

## Type of change
- [] New feature
- [x] Bug Fix

# Implements/Fixes:
* description
previously when logged in as an admin, and clicking on the stations button, clicking on the stations dashboard, then clicking on see all stations, it errors out.

Now it doesn't.

closes #206 

# Check the correct boxes

- [] This broke nothing
- [] This broke some stuff
- [] This broke everything

# Testing Changes
- [x] No Tests have been changed
- [] Some Tests have been changed
- [] All of the Tests have been changed(Please describe what in the world happened)

# Checklist:

- [x] My code has no unused/commented out code
- [x] I have reviewed my code
- [] I have commented my code, particularly in hard-to-understand areas
- [x] I have fully tested my code

# Please Include a link to a gif of your feelings about this branch
Link:
![fireworks-animation-46](https://user-images.githubusercontent.com/38568909/45725451-39809d80-bb78-11e8-82d6-82817fe02110.gif)

